### PR TITLE
Reimplemented result_of in c++ 20

### DIFF
--- a/include/boolinq/boolinq.h
+++ b/include/boolinq/boolinq.h
@@ -20,8 +20,14 @@
 #if (defined(_MSC_VER) && _MSVC_LANG >= 202002L) || __cplusplus >= 202002L
 namespace std
 {
-	template<typename _Callable, typename ..._Args>
-	using result_of = std::invoke_result<_Callable, _Args...>;
+    template<typename>
+    struct result_of;
+
+    template<typename _Callable, typename ..._Args>
+    struct result_of<_Callable(_Args...)>
+    {
+        using type = std::invoke_result<_Callable, _Args...>::type;
+    };
 }
 #endif
 


### PR DESCRIPTION
Replaced a mostly non-functioning hack with a re-implementation of `result_of`.